### PR TITLE
make init.py and solver.py executable (also after copying)

### DIFF
--- a/init.py
+++ b/init.py
@@ -1,6 +1,8 @@
+#!/usr/bin/env python
+
 import os
 from pathlib import Path
-from shutil import copyfile
+from shutil import copyfile, copystat
 import requests
 from datetime import date
 import logging
@@ -32,6 +34,7 @@ def setup_dir(day, languages):
                 logger.warning(f"{newdir} already contains {file}, skipping")
             else:
                 copyfile(template_dir / file, newdir / file)
+                copystat(template_dir / file, newdir / file)
     logger.info(f"done copying templates to {newdir}")
 
 

--- a/templates/py/solver.py
+++ b/templates/py/solver.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from aoc import utils
 
 watch = utils.stopwatch()


### PR DESCRIPTION
This PR adds a `#!/usr/bin/env python` shebang and sets the permissions to 755 for `init.py` and `solver.py`. I also add a `copystat` to ensure this is preserved when copying `solver.py`. That way i can run `init.py` and `solver.py` as executable files.