### PR TITLE
make solver.py work also when called from different directory

### DIFF
--- a/init.py
+++ b/init.py
@@ -1,6 +1,8 @@
+#!/usr/bin/env python
+
 import os
 from pathlib import Path
-from shutil import copyfile
+from shutil import copyfile, copystat
 import requests
 from datetime import date
 import logging
@@ -32,6 +34,7 @@ def setup_dir(day, languages):
                 logger.warning(f"{newdir} already contains {file}, skipping")
             else:
                 copyfile(template_dir / file, newdir / file)
+                copystat(template_dir / file, newdir / file)
     logger.info(f"done copying templates to {newdir}")
 
 

--- a/templates/py/solver.py
+++ b/templates/py/solver.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from pathlib import Path
 from aoc import utils
 
 watch = utils.stopwatch()
@@ -21,7 +22,7 @@ def solve2(data):
 
 
 if __name__ == "__main__":
-    data = parse(open("input.txt").read().strip())
+    data = parse(open(Path(__file__).parent / "input.txt").read().strip())
     print(f"Part 1: {solve1(data)}")
     print(f"Part 2: {solve2(data)}")
     print()

--- a/templates/py/solver.py
+++ b/templates/py/solver.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from aoc import utils
 
 watch = utils.stopwatch()


### PR DESCRIPTION
To achieve this i open the input relative to `Path(__file__).parent`. Just realized i applied this on top of the changes in #1 - so that would need to be merged first. In case you don't want to merge #1, but do want to merge this PR i can also rebase it.